### PR TITLE
Only replace getUserMedia if it already exists

### DIFF
--- a/src/mock-get-user-media.js
+++ b/src/mock-get-user-media.js
@@ -1,29 +1,29 @@
 // Takes a mockOnStreamAvailable function which when given a webrtcstream returns a new stream
 // to replace it with.
 module.exports = function mockGetUserMedia(mockOnStreamAvailable) {
-  let oldGetUserMedia;
-  if (navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia) {
-    oldGetUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia ||
-      navigator.mozGetUserMedia;
-    navigator.webkitGetUserMedia = navigator.getUserMedia = navigator.mozGetUserMedia =
-      function getUserMedia(constraints, onStreamAvailable, onStreamAvailableError,
-                            onAccessDialogOpened, onAccessDialogClosed, onAccessDenied) {
-        return oldGetUserMedia.call(navigator, constraints, stream => {
-          onStreamAvailable(mockOnStreamAvailable(stream));
-        }, onStreamAvailableError,
-        onAccessDialogOpened, onAccessDialogClosed, onAccessDenied);
-      };
-  }
+  let didMock = false;
+
+  ['getUserMedia', 'webkitGetUserMedia', 'mozGetUserMedia'].forEach(gumKey => {
+    if (navigator[gumKey]) {
+      didMock = true;
+      const oldGetUserMedia = navigator[gumKey].bind(navigator);
+      navigator[gumKey] = (constraints, onStreamAvailable, ...args) => (
+        oldGetUserMedia(constraints, stream => (
+          onStreamAvailable(mockOnStreamAvailable(stream))
+        ), ...args)
+      );
+    }
+  });
+
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-    oldGetUserMedia = navigator.mediaDevices.getUserMedia;
-    navigator.mediaDevices.getUserMedia = function getUserMedia(constraints) {
-      return new Promise((resolve, reject) => {
-        oldGetUserMedia.call(navigator.mediaDevices, constraints).then(stream => {
-          resolve(mockOnStreamAvailable(stream));
-        }).catch(reject);
-      });
-    };
-  } else {
+    didMock = true;
+    const oldGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+    navigator.mediaDevices.getUserMedia = constraints => (
+      oldGetUserMedia(constraints).then(mockOnStreamAvailable)
+    );
+  }
+
+  if (!didMock) {
     console.warn('Could not find getUserMedia function to mock out');
   }
 };


### PR DESCRIPTION
Because we always set `mozGetUserMedia` adapter.js (embedded in 2.12) thinks Chrome is Firefox so it shims the wrong things.

Plus some code refactor.