### PR TITLE
Use Safari Stable in the automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ matrix:
     - os: linux
       env: BROWSER=firefox BVER=unstable
     - os: osx
-      osx_image: xcode9
-      env: BROWSER=safari BVER=unstable
+      osx_image: xcode9.2
+      env: BROWSER=safari BVER=stable
   fast_finish: true
   allow_failures:
     - os: linux

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "karma-chrome-launcher": "^1.0.1",
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "^1.0.2",
-    "karma-safaritechpreview-launcher": "0.0.6",
+    "karma-safari-launcher": "^1.0.0",
     "karma-webpack": "^1.7.0",
     "opentok": "^2.3.2",
     "opentok-test-scripts": "^3.6.0",

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -24,7 +24,7 @@ module.exports = config => {
     plugins: [
       'karma-chrome-launcher',
       'karma-firefox-launcher',
-      'karma-safaritechpreview-launcher',
+      'karma-safari-launcher',
       'karma-webpack',
       'karma-jasmine',
     ],
@@ -50,7 +50,7 @@ module.exports = config => {
         },
       },
       safari: {
-        base: 'SafariTechPreview',
+        base: 'Safari',
       },
     },
 


### PR DESCRIPTION
STP is failing because it requires a newer version of Mac OS now.